### PR TITLE
Working example of system/templates/admin overloading

### DIFF
--- a/themes/cockpit_by_monxoops/modules/index.php
+++ b/themes/cockpit_by_monxoops/modules/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/themes/cockpit_by_monxoops/modules/system/admin/index.php
+++ b/themes/cockpit_by_monxoops/modules/system/admin/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");

--- a/themes/cockpit_by_monxoops/modules/system/admin/system_blocks_item.tpl
+++ b/themes/cockpit_by_monxoops/modules/system/admin/system_blocks_item.tpl
@@ -1,0 +1,30 @@
+<{foreach item=item from=$blocks}>
+    <{if $item.side == $side}>
+        <div id="blk_<{$item.bid}>" bid="<{$item.bid}>" side="<{$item.side}>" order="<{$item.weight}>"
+             class="xo-block ui-widget ui-widget-content ui-corner-all">
+            <div class="xo-blocktitle ui-corner-all">
+        <span class="spacer">
+            <img class="xo-imgmini" src="<{xoAdminIcons block.png}>" alt="<{$smarty.const._AM_SYSTEM_BLOCKS_DRAG}>"
+                 title="<{$smarty.const._AM_SYSTEM_BLOCKS_DRAG}>"/>
+        </span>
+<{$item.title}><{if $item.block_type == 'D'}> (<{$item.bid}>)<{/if}>
+            </div>
+            <div class="xo-blockaction xo-actions"><img id="loading_img<{$item.bid}>" src="./images/mimetypes/spinner.gif" style="display:none;"
+                                                        title="<{$smarty.const._AM_SYSTEM_LOADING}>" alt="<{$smarty.const._AM_SYSTEM_LOADING}>"/><img
+                        class="xxtooltip" id="img<{$item.bid}>"
+                        onclick="system_setStatus( { fct: 'blocksadmin', op: 'display', bid: <{$item.bid}>, visible: <{if $item.visible}>0<{else}>1<{/if}> }, 'img<{$item.bid}>', 'admin.php' )"
+                        src="<{if $item.visible}><{xoAdminIcons success.png}><{else}><{xoAdminIcons cancel.png}><{/if}>"
+                        alt="<{if $item.visible}><{$smarty.const._AM_SYSTEM_BLOCKS_HIDE}><{else}><{$smarty.const._AM_SYSTEM_BLOCKS_DISPLAY}><{/if}><{$item.name}>"
+                        title="<{if $item.visible}><{$smarty.const._AM_SYSTEM_BLOCKS_HIDE}><{else}><{$smarty.const._AM_SYSTEM_BLOCKS_DISPLAY}><{/if}><{$item.name}>"/>
+                <a class="xxtooltip" href="admin.php?fct=blocksadmin&amp;op=edit&amp;bid=<{$item.bid}>" title="<{$smarty.const._EDIT}>">
+                    <img src="<{xoAdminIcons edit.png}>" alt="<{$smarty.const._EDIT}>"/></a>
+                <{if $item.block_type != 'S'}>
+                    <a class="xxtooltip" href="admin.php?fct=blocksadmin&amp;op=delete&amp;bid=<{$item.bid}>" title="<{$smarty.const._DELETE}>">
+                        <img src="<{xoAdminIcons delete.png}>" alt="<{$smarty.const._DELETE}>"/></a>
+                <{/if}>
+                <a class="xxtooltip" href="admin.php?fct=blocksadmin&amp;op=clone&amp;bid=<{$item.bid}>" title="<{$smarty.const._AM_SYSTEM_BLOCKS_CLONE}>">
+                    <img src="<{xoAdminIcons clone.png}>" alt="<{$smarty.const._AM_SYSTEM_BLOCKS_CLONE}>"/></a>
+            </div>
+        </div>
+    <{/if}>
+<{/foreach}>

--- a/themes/cockpit_by_monxoops/modules/system/index.php
+++ b/themes/cockpit_by_monxoops/modules/system/index.php
@@ -1,0 +1,2 @@
+<?php
+header("HTTP/1.0 404 Not Found");


### PR DESCRIPTION
This adds a system_blocks_item.tpl with a simple change of all the class tooltip references changed to xxtooltip.

With change the action icons are restored on the blocks display on system/admin.php?fct=blocksadmin

This example shows the way to overload the existing template with bootstrap compatible ones.

![blocksadmin](https://user-images.githubusercontent.com/3181636/110868265-e5109180-828d-11eb-8727-7cfe18f416f2.png)
